### PR TITLE
Fix signal emitter panics on write after close

### DIFF
--- a/address-resolver.go
+++ b/address-resolver.go
@@ -29,7 +29,6 @@ func (c *AddressResolver) interfaceForMember(method string) string {
 
 func (c *AddressResolver) free() {
 	close(c.closeCh)
-	close(c.FoundChannel)
 	c.object.Call(c.interfaceForMember("Free"), 0)
 }
 
@@ -50,6 +49,7 @@ func (c *AddressResolver) dispatchSignal(signal *dbus.Signal) error {
 		select {
 		case c.FoundChannel <- address:
 		case <-c.closeCh:
+			close(c.FoundChannel)
 		}
 	}
 

--- a/domain-browser.go
+++ b/domain-browser.go
@@ -44,8 +44,6 @@ func (c *DomainBrowser) interfaceForMember(method string) string {
 
 func (c *DomainBrowser) free() {
 	close(c.closeCh)
-	close(c.AddChannel)
-	close(c.RemoveChannel)
 	c.object.Call(c.interfaceForMember("Free"), 0)
 }
 
@@ -65,11 +63,15 @@ func (c *DomainBrowser) dispatchSignal(signal *dbus.Signal) error {
 			select {
 			case c.AddChannel <- domain:
 			case <-c.closeCh:
+				close(c.AddChannel)
+				close(c.RemoveChannel)
 			}
 		} else {
 			select {
 			case c.RemoveChannel <- domain:
 			case <-c.closeCh:
+				close(c.AddChannel)
+				close(c.RemoveChannel)
 			}
 		}
 	}

--- a/host-name-resolver.go
+++ b/host-name-resolver.go
@@ -29,7 +29,6 @@ func (c *HostNameResolver) interfaceForMember(method string) string {
 
 func (c *HostNameResolver) free() {
 	close(c.closeCh)
-	close(c.FoundChannel)
 	c.object.Call(c.interfaceForMember("Free"), 0)
 }
 
@@ -50,6 +49,7 @@ func (c *HostNameResolver) dispatchSignal(signal *dbus.Signal) error {
 		select {
 		case c.FoundChannel <- hostName:
 		case <-c.closeCh:
+			close(c.FoundChannel)
 		}
 	}
 

--- a/service-browser.go
+++ b/service-browser.go
@@ -31,8 +31,6 @@ func (c *ServiceBrowser) interfaceForMember(method string) string {
 
 func (c *ServiceBrowser) free() {
 	close(c.closeCh)
-	close(c.AddChannel)
-	close(c.RemoveChannel)
 	c.object.Call(c.interfaceForMember("Free"), 0)
 }
 
@@ -52,11 +50,15 @@ func (c *ServiceBrowser) dispatchSignal(signal *dbus.Signal) error {
 			select {
 			case c.AddChannel <- service:
 			case <-c.closeCh:
+				close(c.AddChannel)
+				close(c.RemoveChannel)
 			}
 		} else {
 			select {
 			case c.RemoveChannel <- service:
 			case <-c.closeCh:
+				close(c.AddChannel)
+				close(c.RemoveChannel)
 			}
 		}
 	}

--- a/service-resolver.go
+++ b/service-resolver.go
@@ -30,7 +30,6 @@ func (c *ServiceResolver) interfaceForMember(method string) string {
 
 func (c *ServiceResolver) free() {
 	close(c.closeCh)
-	close(c.FoundChannel)
 	c.object.Call(c.interfaceForMember("Free"), 0)
 }
 
@@ -52,6 +51,7 @@ func (c *ServiceResolver) dispatchSignal(signal *dbus.Signal) error {
 		select {
 		case c.FoundChannel <- service:
 		case <-c.closeCh:
+			close(c.FoundChannel)
 		}
 	}
 

--- a/service-type-browser.go
+++ b/service-type-browser.go
@@ -32,8 +32,6 @@ func (c *ServiceTypeBrowser) interfaceForMember(method string) string {
 
 func (c *ServiceTypeBrowser) free() {
 	close(c.closeCh)
-	close(c.AddChannel)
-	close(c.RemoveChannel)
 	c.object.Call(c.interfaceForMember("Free"), 0)
 }
 
@@ -53,11 +51,15 @@ func (c *ServiceTypeBrowser) dispatchSignal(signal *dbus.Signal) error {
 			select {
 			case c.AddChannel <- serviceType:
 			case <-c.closeCh:
+				close(c.AddChannel)
+				close(c.RemoveChannel)
 			}
 		} else {
 			select {
 			case c.RemoveChannel <- serviceType:
 			case <-c.closeCh:
+				close(c.AddChannel)
+				close(c.RemoveChannel)
 			}
 		}
 	}


### PR DESCRIPTION
The dispatchSignal methods are no responsible for closing the channels
they write to.