### PR TITLE
Added missing make for close channels

### DIFF
--- a/address-resolver.go
+++ b/address-resolver.go
@@ -19,6 +19,7 @@ func AddressResolverNew(conn *dbus.Conn, path dbus.ObjectPath) (*AddressResolver
 
 	c.object = conn.Object("org.freedesktop.Avahi", path)
 	c.FoundChannel = make(chan Address)
+	c.closeCh = make(chan struct{})
 
 	return c, nil
 }

--- a/domain-browser.go
+++ b/domain-browser.go
@@ -34,6 +34,7 @@ func DomainBrowserNew(conn *dbus.Conn, path dbus.ObjectPath) (*DomainBrowser, er
 	c.object = conn.Object("org.freedesktop.Avahi", path)
 	c.AddChannel = make(chan Domain)
 	c.RemoveChannel = make(chan Domain)
+	c.closeCh = make(chan struct{})
 
 	return c, nil
 }

--- a/host-name-resolver.go
+++ b/host-name-resolver.go
@@ -19,6 +19,7 @@ func HostNameResolverNew(conn *dbus.Conn, path dbus.ObjectPath) (*HostNameResolv
 
 	c.object = conn.Object("org.freedesktop.Avahi", path)
 	c.FoundChannel = make(chan HostName)
+	c.closeCh = make(chan struct{})
 
 	return c, nil
 }

--- a/record-browser.go
+++ b/record-browser.go
@@ -21,6 +21,7 @@ func RecordBrowserNew(conn *dbus.Conn, path dbus.ObjectPath) (*RecordBrowser, er
 	c.object = conn.Object("org.freedesktop.Avahi", path)
 	c.AddChannel = make(chan Record)
 	c.RemoveChannel = make(chan Record)
+	c.closeCh = make(chan struct{})
 
 	return c, nil
 }

--- a/server.go
+++ b/server.go
@@ -55,7 +55,7 @@ func ServerNew(conn *dbus.Conn) (*Server, error) {
 				c.mutex.Lock()
 				for path, obj := range c.signalEmitters {
 					if path == signal.Path {
-						obj.dispatchSignal(signal)
+						_ = obj.dispatchSignal(signal)
 					}
 				}
 				c.mutex.Unlock()

--- a/service-browser.go
+++ b/service-browser.go
@@ -21,6 +21,7 @@ func ServiceBrowserNew(conn *dbus.Conn, path dbus.ObjectPath) (*ServiceBrowser, 
 	c.object = conn.Object("org.freedesktop.Avahi", path)
 	c.AddChannel = make(chan Service)
 	c.RemoveChannel = make(chan Service)
+	c.closeCh = make(chan struct{})
 
 	return c, nil
 }


### PR DESCRIPTION
Without these, invoking e.g. `ServiceBrowserFree` would crash, as it tries to close the `closeCh` channel, which never was created.