### PR TITLE
Fix panic on closing closed channels

### DIFF
--- a/address-resolver.go
+++ b/address-resolver.go
@@ -50,9 +50,21 @@ func (c *AddressResolver) dispatchSignal(signal *dbus.Signal) error {
 		select {
 		case c.FoundChannel <- address:
 		case <-c.closeCh:
-			close(c.FoundChannel)
+			if !c.isChannelClosed(c.FoundChannel) {
+				close(c.FoundChannel)
+			}
 		}
 	}
 
 	return nil
+}
+
+// check if a provided channel is closed
+func (c *AddressResolver) isChannelClosed(ch <-chan Address) bool {
+	select {
+	case <-ch:
+		return false
+	default:
+		return true
+	}
 }

--- a/address-resolver.go
+++ b/address-resolver.go
@@ -50,21 +50,10 @@ func (c *AddressResolver) dispatchSignal(signal *dbus.Signal) error {
 		select {
 		case c.FoundChannel <- address:
 		case <-c.closeCh:
-			if !c.isChannelClosed(c.FoundChannel) {
-				close(c.FoundChannel)
-			}
+			close(c.FoundChannel)
+			c.closeCh = nil
 		}
 	}
 
 	return nil
-}
-
-// check if a provided channel is closed
-func (c *AddressResolver) isChannelClosed(ch <-chan Address) bool {
-	select {
-	case <-ch:
-		return false
-	default:
-		return true
-	}
 }

--- a/domain-browser.go
+++ b/domain-browser.go
@@ -64,18 +64,36 @@ func (c *DomainBrowser) dispatchSignal(signal *dbus.Signal) error {
 			select {
 			case c.AddChannel <- domain:
 			case <-c.closeCh:
-				close(c.AddChannel)
-				close(c.RemoveChannel)
+				if !c.isChannelClosed(c.AddChannel) {
+					close(c.AddChannel)
+				}
+				if !c.isChannelClosed(c.RemoveChannel) {
+					close(c.RemoveChannel)
+				}
 			}
 		} else {
 			select {
 			case c.RemoveChannel <- domain:
 			case <-c.closeCh:
-				close(c.AddChannel)
-				close(c.RemoveChannel)
+				if !c.isChannelClosed(c.AddChannel) {
+					close(c.AddChannel)
+				}
+				if !c.isChannelClosed(c.RemoveChannel) {
+					close(c.RemoveChannel)
+				}
 			}
 		}
 	}
 
 	return nil
+}
+
+// check if a provided channel is closed
+func (c *DomainBrowser) isChannelClosed(ch <-chan Domain) bool {
+	select {
+	case <-ch:
+		return false
+	default:
+		return true
+	}
 }

--- a/domain-browser.go
+++ b/domain-browser.go
@@ -64,36 +64,20 @@ func (c *DomainBrowser) dispatchSignal(signal *dbus.Signal) error {
 			select {
 			case c.AddChannel <- domain:
 			case <-c.closeCh:
-				if !c.isChannelClosed(c.AddChannel) {
-					close(c.AddChannel)
-				}
-				if !c.isChannelClosed(c.RemoveChannel) {
-					close(c.RemoveChannel)
-				}
+				close(c.AddChannel)
+				close(c.RemoveChannel)
+				c.closeCh = nil
 			}
 		} else {
 			select {
 			case c.RemoveChannel <- domain:
 			case <-c.closeCh:
-				if !c.isChannelClosed(c.AddChannel) {
-					close(c.AddChannel)
-				}
-				if !c.isChannelClosed(c.RemoveChannel) {
-					close(c.RemoveChannel)
-				}
+				close(c.AddChannel)
+				close(c.RemoveChannel)
+				c.closeCh = nil
 			}
 		}
 	}
 
 	return nil
-}
-
-// check if a provided channel is closed
-func (c *DomainBrowser) isChannelClosed(ch <-chan Domain) bool {
-	select {
-	case <-ch:
-		return false
-	default:
-		return true
-	}
 }

--- a/host-name-resolver.go
+++ b/host-name-resolver.go
@@ -50,9 +50,21 @@ func (c *HostNameResolver) dispatchSignal(signal *dbus.Signal) error {
 		select {
 		case c.FoundChannel <- hostName:
 		case <-c.closeCh:
-			close(c.FoundChannel)
+			if !c.isChannelClosed(c.FoundChannel) {
+				close(c.FoundChannel)
+			}
 		}
 	}
 
 	return nil
+}
+
+// check if a provided channel is closed
+func (c *HostNameResolver) isChannelClosed(ch <-chan HostName) bool {
+	select {
+	case <-ch:
+		return false
+	default:
+		return true
+	}
 }

--- a/host-name-resolver.go
+++ b/host-name-resolver.go
@@ -50,21 +50,10 @@ func (c *HostNameResolver) dispatchSignal(signal *dbus.Signal) error {
 		select {
 		case c.FoundChannel <- hostName:
 		case <-c.closeCh:
-			if !c.isChannelClosed(c.FoundChannel) {
-				close(c.FoundChannel)
-			}
+			close(c.FoundChannel)
+			c.closeCh = nil
 		}
 	}
 
 	return nil
-}
-
-// check if a provided channel is closed
-func (c *HostNameResolver) isChannelClosed(ch <-chan HostName) bool {
-	select {
-	case <-ch:
-		return false
-	default:
-		return true
-	}
 }

--- a/service-browser.go
+++ b/service-browser.go
@@ -51,36 +51,20 @@ func (c *ServiceBrowser) dispatchSignal(signal *dbus.Signal) error {
 			select {
 			case c.AddChannel <- service:
 			case <-c.closeCh:
-				if !c.isChannelClosed(c.AddChannel) {
-					close(c.AddChannel)
-				}
-				if !c.isChannelClosed(c.RemoveChannel) {
-					close(c.RemoveChannel)
-				}
+				close(c.AddChannel)
+				close(c.RemoveChannel)
+				c.closeCh = nil
 			}
 		} else {
 			select {
 			case c.RemoveChannel <- service:
 			case <-c.closeCh:
-				if !c.isChannelClosed(c.AddChannel) {
-					close(c.AddChannel)
-				}
-				if !c.isChannelClosed(c.RemoveChannel) {
-					close(c.RemoveChannel)
-				}
+				close(c.AddChannel)
+				close(c.RemoveChannel)
+				c.closeCh = nil
 			}
 		}
 	}
 
 	return nil
-}
-
-// check if a provided channel is closed
-func (c *ServiceBrowser) isChannelClosed(ch <-chan Service) bool {
-	select {
-	case <-ch:
-		return false
-	default:
-		return true
-	}
 }

--- a/service-browser.go
+++ b/service-browser.go
@@ -51,18 +51,36 @@ func (c *ServiceBrowser) dispatchSignal(signal *dbus.Signal) error {
 			select {
 			case c.AddChannel <- service:
 			case <-c.closeCh:
-				close(c.AddChannel)
-				close(c.RemoveChannel)
+				if !c.isChannelClosed(c.AddChannel) {
+					close(c.AddChannel)
+				}
+				if !c.isChannelClosed(c.RemoveChannel) {
+					close(c.RemoveChannel)
+				}
 			}
 		} else {
 			select {
 			case c.RemoveChannel <- service:
 			case <-c.closeCh:
-				close(c.AddChannel)
-				close(c.RemoveChannel)
+				if !c.isChannelClosed(c.AddChannel) {
+					close(c.AddChannel)
+				}
+				if !c.isChannelClosed(c.RemoveChannel) {
+					close(c.RemoveChannel)
+				}
 			}
 		}
 	}
 
 	return nil
+}
+
+// check if a provided channel is closed
+func (c *ServiceBrowser) isChannelClosed(ch <-chan Service) bool {
+	select {
+	case <-ch:
+		return false
+	default:
+		return true
+	}
 }

--- a/service-resolver.go
+++ b/service-resolver.go
@@ -51,9 +51,21 @@ func (c *ServiceResolver) dispatchSignal(signal *dbus.Signal) error {
 		select {
 		case c.FoundChannel <- service:
 		case <-c.closeCh:
-			close(c.FoundChannel)
+			if !c.isChannelClosed(c.FoundChannel) {
+				close(c.FoundChannel)
+			}
 		}
 	}
 
 	return nil
+}
+
+// check if a provided channel is closed
+func (c *ServiceResolver) isChannelClosed(ch <-chan Service) bool {
+	select {
+	case <-ch:
+		return false
+	default:
+		return true
+	}
 }

--- a/service-resolver.go
+++ b/service-resolver.go
@@ -51,21 +51,10 @@ func (c *ServiceResolver) dispatchSignal(signal *dbus.Signal) error {
 		select {
 		case c.FoundChannel <- service:
 		case <-c.closeCh:
-			if !c.isChannelClosed(c.FoundChannel) {
-				close(c.FoundChannel)
-			}
+			close(c.FoundChannel)
+			c.closeCh = nil
 		}
 	}
 
 	return nil
-}
-
-// check if a provided channel is closed
-func (c *ServiceResolver) isChannelClosed(ch <-chan Service) bool {
-	select {
-	case <-ch:
-		return false
-	default:
-		return true
-	}
 }

--- a/service-type-browser.go
+++ b/service-type-browser.go
@@ -51,36 +51,20 @@ func (c *ServiceTypeBrowser) dispatchSignal(signal *dbus.Signal) error {
 			select {
 			case c.AddChannel <- serviceType:
 			case <-c.closeCh:
-				if !c.isChannelClosed(c.AddChannel) {
-					close(c.AddChannel)
-				}
-				if !c.isChannelClosed(c.RemoveChannel) {
-					close(c.RemoveChannel)
-				}
+				close(c.AddChannel)
+				close(c.RemoveChannel)
+				c.closeCh = nil
 			}
 		} else {
 			select {
 			case c.RemoveChannel <- serviceType:
 			case <-c.closeCh:
-				if !c.isChannelClosed(c.AddChannel) {
-					close(c.AddChannel)
-				}
-				if !c.isChannelClosed(c.RemoveChannel) {
-					close(c.RemoveChannel)
-				}
+				close(c.AddChannel)
+				close(c.RemoveChannel)
+				c.closeCh = nil
 			}
 		}
 	}
 
 	return nil
-}
-
-// check if a provided channel is closed
-func (c *ServiceTypeBrowser) isChannelClosed(ch <-chan ServiceType) bool {
-	select {
-	case <-ch:
-		return false
-	default:
-		return true
-	}
 }

--- a/service-type-browser.go
+++ b/service-type-browser.go
@@ -51,18 +51,36 @@ func (c *ServiceTypeBrowser) dispatchSignal(signal *dbus.Signal) error {
 			select {
 			case c.AddChannel <- serviceType:
 			case <-c.closeCh:
-				close(c.AddChannel)
-				close(c.RemoveChannel)
+				if !c.isChannelClosed(c.AddChannel) {
+					close(c.AddChannel)
+				}
+				if !c.isChannelClosed(c.RemoveChannel) {
+					close(c.RemoveChannel)
+				}
 			}
 		} else {
 			select {
 			case c.RemoveChannel <- serviceType:
 			case <-c.closeCh:
-				close(c.AddChannel)
-				close(c.RemoveChannel)
+				if !c.isChannelClosed(c.AddChannel) {
+					close(c.AddChannel)
+				}
+				if !c.isChannelClosed(c.RemoveChannel) {
+					close(c.RemoveChannel)
+				}
 			}
 		}
 	}
 
 	return nil
+}
+
+// check if a provided channel is closed
+func (c *ServiceTypeBrowser) isChannelClosed(ch <-chan ServiceType) bool {
+	select {
+	case <-ch:
+		return false
+	default:
+		return true
+	}
 }


### PR DESCRIPTION
Sometimes getting these crashes:

```
panic: send on closed channel

goroutine 11 [running]:
github.com/holoplot/go-avahi.(*ServiceBrowser).dispatchSignal(0x347f440, 0x3494330)
	/Users/…/go/pkg/mod/github.com/holoplot/go-avahi@v1.0.1/service-browser.go:51 +0x3c8
github.com/holoplot/go-avahi.ServerNew.func1()
	/Users/…/go/pkg/mod/github.com/holoplot/go-avahi@v1.0.1/server.go:58 +0x180
created by github.com/holoplot/go-avahi.ServerNew in goroutine 1
	/Users/…/go/pkg/mod/github.com/holoplot/go-avahi@v1.0.1/server.go:47 +0x26c
```

So adding checks if a channel is already closed before closing it