### PR TITLE
Fix panic if dispatcher is invoked after free

### DIFF
--- a/address-resolver.go
+++ b/address-resolver.go
@@ -30,6 +30,7 @@ func (c *AddressResolver) interfaceForMember(method string) string {
 
 func (c *AddressResolver) free() {
 	close(c.closeCh)
+	c.closeCh = nil
 	c.object.Call(c.interfaceForMember("Free"), 0)
 }
 
@@ -38,6 +39,9 @@ func (c *AddressResolver) getObjectPath() dbus.ObjectPath {
 }
 
 func (c *AddressResolver) dispatchSignal(signal *dbus.Signal) error {
+	if c.closeCh == nil {
+		return nil
+	}
 	if signal.Name == c.interfaceForMember("Found") {
 		var address Address
 		err := dbus.Store(signal.Body, &address.Interface, &address.Protocol,

--- a/address-resolver.go
+++ b/address-resolver.go
@@ -30,7 +30,6 @@ func (c *AddressResolver) interfaceForMember(method string) string {
 
 func (c *AddressResolver) free() {
 	close(c.closeCh)
-	c.closeCh = nil
 	c.object.Call(c.interfaceForMember("Free"), 0)
 }
 
@@ -39,9 +38,6 @@ func (c *AddressResolver) getObjectPath() dbus.ObjectPath {
 }
 
 func (c *AddressResolver) dispatchSignal(signal *dbus.Signal) error {
-	if c.closeCh == nil {
-		return nil
-	}
 	if signal.Name == c.interfaceForMember("Found") {
 		var address Address
 		err := dbus.Store(signal.Body, &address.Interface, &address.Protocol,

--- a/address-resolver.go
+++ b/address-resolver.go
@@ -29,7 +29,9 @@ func (c *AddressResolver) interfaceForMember(method string) string {
 }
 
 func (c *AddressResolver) free() {
-	close(c.closeCh)
+	if c.closeCh != nil {
+		close(c.closeCh)
+	}
 	c.object.Call(c.interfaceForMember("Free"), 0)
 }
 

--- a/domain-browser.go
+++ b/domain-browser.go
@@ -45,7 +45,6 @@ func (c *DomainBrowser) interfaceForMember(method string) string {
 
 func (c *DomainBrowser) free() {
 	close(c.closeCh)
-	c.closeCh = nil
 	c.object.Call(c.interfaceForMember("Free"), 0)
 }
 
@@ -54,9 +53,6 @@ func (c *DomainBrowser) getObjectPath() dbus.ObjectPath {
 }
 
 func (c *DomainBrowser) dispatchSignal(signal *dbus.Signal) error {
-	if c.closeCh == nil {
-		return nil
-	}
 	if signal.Name == c.interfaceForMember("ItemNew") || signal.Name == c.interfaceForMember("ItemRemove") {
 		var domain Domain
 		err := dbus.Store(signal.Body, &domain.Interface, &domain.Protocol, &domain.Domain, &domain.Flags)

--- a/domain-browser.go
+++ b/domain-browser.go
@@ -45,6 +45,7 @@ func (c *DomainBrowser) interfaceForMember(method string) string {
 
 func (c *DomainBrowser) free() {
 	close(c.closeCh)
+	c.closeCh = nil
 	c.object.Call(c.interfaceForMember("Free"), 0)
 }
 
@@ -53,6 +54,9 @@ func (c *DomainBrowser) getObjectPath() dbus.ObjectPath {
 }
 
 func (c *DomainBrowser) dispatchSignal(signal *dbus.Signal) error {
+	if c.closeCh == nil {
+		return nil
+	}
 	if signal.Name == c.interfaceForMember("ItemNew") || signal.Name == c.interfaceForMember("ItemRemove") {
 		var domain Domain
 		err := dbus.Store(signal.Body, &domain.Interface, &domain.Protocol, &domain.Domain, &domain.Flags)

--- a/domain-browser.go
+++ b/domain-browser.go
@@ -44,7 +44,9 @@ func (c *DomainBrowser) interfaceForMember(method string) string {
 }
 
 func (c *DomainBrowser) free() {
-	close(c.closeCh)
+	if c.closeCh != nil {
+		close(c.closeCh)
+	}
 	c.object.Call(c.interfaceForMember("Free"), 0)
 }
 

--- a/host-name-resolver.go
+++ b/host-name-resolver.go
@@ -29,7 +29,9 @@ func (c *HostNameResolver) interfaceForMember(method string) string {
 }
 
 func (c *HostNameResolver) free() {
-	close(c.closeCh)
+	if c.closeCh != nil {
+		close(c.closeCh)
+	}
 	c.object.Call(c.interfaceForMember("Free"), 0)
 }
 

--- a/host-name-resolver.go
+++ b/host-name-resolver.go
@@ -30,7 +30,6 @@ func (c *HostNameResolver) interfaceForMember(method string) string {
 
 func (c *HostNameResolver) free() {
 	close(c.closeCh)
-	c.closeCh = nil
 	c.object.Call(c.interfaceForMember("Free"), 0)
 }
 
@@ -39,9 +38,6 @@ func (c *HostNameResolver) getObjectPath() dbus.ObjectPath {
 }
 
 func (c *HostNameResolver) dispatchSignal(signal *dbus.Signal) error {
-	if c.closeCh == nil {
-		return nil
-	}
 	if signal.Name == c.interfaceForMember("Found") {
 		var hostName HostName
 		err := dbus.Store(signal.Body, &hostName.Interface, &hostName.Protocol,

--- a/host-name-resolver.go
+++ b/host-name-resolver.go
@@ -30,6 +30,7 @@ func (c *HostNameResolver) interfaceForMember(method string) string {
 
 func (c *HostNameResolver) free() {
 	close(c.closeCh)
+	c.closeCh = nil
 	c.object.Call(c.interfaceForMember("Free"), 0)
 }
 
@@ -38,6 +39,9 @@ func (c *HostNameResolver) getObjectPath() dbus.ObjectPath {
 }
 
 func (c *HostNameResolver) dispatchSignal(signal *dbus.Signal) error {
+	if c.closeCh == nil {
+		return nil
+	}
 	if signal.Name == c.interfaceForMember("Found") {
 		var hostName HostName
 		err := dbus.Store(signal.Body, &hostName.Interface, &hostName.Protocol,

--- a/record-browser.go
+++ b/record-browser.go
@@ -32,7 +32,6 @@ func (c *RecordBrowser) interfaceForMember(method string) string {
 
 func (c *RecordBrowser) free() {
 	close(c.closeCh)
-	c.closeCh = nil
 	close(c.AddChannel)
 	close(c.RemoveChannel)
 	c.object.Call(c.interfaceForMember("Free"), 0)
@@ -43,9 +42,6 @@ func (c *RecordBrowser) getObjectPath() dbus.ObjectPath {
 }
 
 func (c *RecordBrowser) dispatchSignal(signal *dbus.Signal) error {
-	if c.closeCh == nil {
-		return nil
-	}
 	if signal.Name == c.interfaceForMember("ItemNew") || signal.Name == c.interfaceForMember("ItemRemove") {
 		var record Record
 		err := dbus.Store(signal.Body, &record.Interface, &record.Protocol, &record.Name,

--- a/record-browser.go
+++ b/record-browser.go
@@ -32,6 +32,7 @@ func (c *RecordBrowser) interfaceForMember(method string) string {
 
 func (c *RecordBrowser) free() {
 	close(c.closeCh)
+	c.closeCh = nil
 	close(c.AddChannel)
 	close(c.RemoveChannel)
 	c.object.Call(c.interfaceForMember("Free"), 0)
@@ -42,6 +43,9 @@ func (c *RecordBrowser) getObjectPath() dbus.ObjectPath {
 }
 
 func (c *RecordBrowser) dispatchSignal(signal *dbus.Signal) error {
+	if c.closeCh == nil {
+		return nil
+	}
 	if signal.Name == c.interfaceForMember("ItemNew") || signal.Name == c.interfaceForMember("ItemRemove") {
 		var record Record
 		err := dbus.Store(signal.Body, &record.Interface, &record.Protocol, &record.Name,

--- a/service-browser.go
+++ b/service-browser.go
@@ -32,7 +32,6 @@ func (c *ServiceBrowser) interfaceForMember(method string) string {
 
 func (c *ServiceBrowser) free() {
 	close(c.closeCh)
-	c.closeCh = nil
 	c.object.Call(c.interfaceForMember("Free"), 0)
 }
 
@@ -41,9 +40,6 @@ func (c *ServiceBrowser) getObjectPath() dbus.ObjectPath {
 }
 
 func (c *ServiceBrowser) dispatchSignal(signal *dbus.Signal) error {
-	if c.closeCh == nil {
-		return nil
-	}
 	if signal.Name == c.interfaceForMember("ItemNew") || signal.Name == c.interfaceForMember("ItemRemove") {
 		var service Service
 		err := dbus.Store(signal.Body, &service.Interface, &service.Protocol, &service.Name, &service.Type, &service.Domain, &service.Flags)

--- a/service-browser.go
+++ b/service-browser.go
@@ -32,6 +32,7 @@ func (c *ServiceBrowser) interfaceForMember(method string) string {
 
 func (c *ServiceBrowser) free() {
 	close(c.closeCh)
+	c.closeCh = nil
 	c.object.Call(c.interfaceForMember("Free"), 0)
 }
 
@@ -40,6 +41,9 @@ func (c *ServiceBrowser) getObjectPath() dbus.ObjectPath {
 }
 
 func (c *ServiceBrowser) dispatchSignal(signal *dbus.Signal) error {
+	if c.closeCh == nil {
+		return nil
+	}
 	if signal.Name == c.interfaceForMember("ItemNew") || signal.Name == c.interfaceForMember("ItemRemove") {
 		var service Service
 		err := dbus.Store(signal.Body, &service.Interface, &service.Protocol, &service.Name, &service.Type, &service.Domain, &service.Flags)

--- a/service-browser.go
+++ b/service-browser.go
@@ -31,7 +31,9 @@ func (c *ServiceBrowser) interfaceForMember(method string) string {
 }
 
 func (c *ServiceBrowser) free() {
-	close(c.closeCh)
+	if c.closeCh != nil {
+		close(c.closeCh)
+	}
 	c.object.Call(c.interfaceForMember("Free"), 0)
 }
 

--- a/service-resolver.go
+++ b/service-resolver.go
@@ -29,7 +29,9 @@ func (c *ServiceResolver) interfaceForMember(method string) string {
 }
 
 func (c *ServiceResolver) free() {
-	close(c.closeCh)
+	if c.closeCh != nil {
+		close(c.closeCh)
+	}
 	c.object.Call(c.interfaceForMember("Free"), 0)
 }
 

--- a/service-resolver.go
+++ b/service-resolver.go
@@ -30,6 +30,7 @@ func (c *ServiceResolver) interfaceForMember(method string) string {
 
 func (c *ServiceResolver) free() {
 	close(c.closeCh)
+	c.closeCh = nil
 	c.object.Call(c.interfaceForMember("Free"), 0)
 }
 
@@ -38,6 +39,9 @@ func (c *ServiceResolver) getObjectPath() dbus.ObjectPath {
 }
 
 func (c *ServiceResolver) dispatchSignal(signal *dbus.Signal) error {
+	if c.closeCh == nil {
+		return nil
+	}
 	if signal.Name == c.interfaceForMember("Found") {
 		var service Service
 		err := dbus.Store(signal.Body, &service.Interface, &service.Protocol,

--- a/service-resolver.go
+++ b/service-resolver.go
@@ -30,7 +30,6 @@ func (c *ServiceResolver) interfaceForMember(method string) string {
 
 func (c *ServiceResolver) free() {
 	close(c.closeCh)
-	c.closeCh = nil
 	c.object.Call(c.interfaceForMember("Free"), 0)
 }
 
@@ -39,9 +38,6 @@ func (c *ServiceResolver) getObjectPath() dbus.ObjectPath {
 }
 
 func (c *ServiceResolver) dispatchSignal(signal *dbus.Signal) error {
-	if c.closeCh == nil {
-		return nil
-	}
 	if signal.Name == c.interfaceForMember("Found") {
 		var service Service
 		err := dbus.Store(signal.Body, &service.Interface, &service.Protocol,

--- a/service-type-browser.go
+++ b/service-type-browser.go
@@ -32,7 +32,6 @@ func (c *ServiceTypeBrowser) interfaceForMember(method string) string {
 
 func (c *ServiceTypeBrowser) free() {
 	close(c.closeCh)
-	c.closeCh = nil
 	c.object.Call(c.interfaceForMember("Free"), 0)
 }
 
@@ -41,9 +40,6 @@ func (c *ServiceTypeBrowser) getObjectPath() dbus.ObjectPath {
 }
 
 func (c *ServiceTypeBrowser) dispatchSignal(signal *dbus.Signal) error {
-	if c.closeCh == nil {
-		return nil
-	}
 	if signal.Name == c.interfaceForMember("ItemNew") || signal.Name == c.interfaceForMember("ItemRemove") {
 		var serviceType ServiceType
 		err := dbus.Store(signal.Body, &serviceType.Interface, &serviceType.Protocol, &serviceType.Type, &serviceType.Domain, &serviceType.Flags)

--- a/service-type-browser.go
+++ b/service-type-browser.go
@@ -32,6 +32,7 @@ func (c *ServiceTypeBrowser) interfaceForMember(method string) string {
 
 func (c *ServiceTypeBrowser) free() {
 	close(c.closeCh)
+	c.closeCh = nil
 	c.object.Call(c.interfaceForMember("Free"), 0)
 }
 
@@ -40,6 +41,9 @@ func (c *ServiceTypeBrowser) getObjectPath() dbus.ObjectPath {
 }
 
 func (c *ServiceTypeBrowser) dispatchSignal(signal *dbus.Signal) error {
+	if c.closeCh == nil {
+		return nil
+	}
 	if signal.Name == c.interfaceForMember("ItemNew") || signal.Name == c.interfaceForMember("ItemRemove") {
 		var serviceType ServiceType
 		err := dbus.Store(signal.Body, &serviceType.Interface, &serviceType.Protocol, &serviceType.Type, &serviceType.Domain, &serviceType.Flags)

--- a/service-type-browser.go
+++ b/service-type-browser.go
@@ -31,7 +31,9 @@ func (c *ServiceTypeBrowser) interfaceForMember(method string) string {
 }
 
 func (c *ServiceTypeBrowser) free() {
-	close(c.closeCh)
+	if c.closeCh != nil {
+		close(c.closeCh)
+	}
 	c.object.Call(c.interfaceForMember("Free"), 0)
 }
 

--- a/signal-emitter.go
+++ b/signal-emitter.go
@@ -10,7 +10,6 @@ type signalEmitter interface {
 
 func (c *Server) signalEmitterFree(e signalEmitter) {
 	o := e.getObjectPath()
-	e.free()
 
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
@@ -19,4 +18,6 @@ func (c *Server) signalEmitterFree(e signalEmitter) {
 	if ok {
 		delete(c.signalEmitters, o)
 	}
+
+	e.free()
 }


### PR DESCRIPTION
This fixes the following panic:

```
panic: close of closed channel

goroutine 9 [running]:
github.com/holoplot/go-avahi.(*ServiceBrowser).dispatchSignal(0x20174d0, 0x207e870)
	/Users/xxx/go/pkg/mod/github.com/holoplot/go-avahi@v1.0.1/service-browser.go:54 +0x3e4
github.com/holoplot/go-avahi.ServerNew.func1()
	/Users/xxx/go/pkg/mod/github.com/holoplot/go-avahi@v1.0.1/server.go:58 +0x180
created by github.com/holoplot/go-avahi.ServerNew in goroutine 1
	/Users/xxx/go/pkg/mod/github.com/holoplot/go-avahi@v1.0.1/server.go:47 +0x26c
```

dispatchSignal() is invoked with new service entries after free() is called

In addition this fixes another panic:

```

"close of closed channel"
Stack: 3 0x00000000009a7025 in github.com/holoplot/go-avahi.(*ServiceBrowser).free
	at /…/github.com/!der!andere!andi/go-avahi@v0.0.0-20240123155759-b4b6b2b50b4d/service-browser.go:34
4 0x00000000009a7a9a in github.com/holoplot/go-avahi.(*Server).signalEmitterFree
	at /…/github.com/!der!andere!andi/go-avahi@v0.0.0-20240123155759-b4b6b2b50b4d/signal-emitter.go:22
5 0x00000000009a6ae7 in github.com/holoplot/go-avahi.(*Server).ServiceBrowserFree
	at /…/github.com/!der!andere!andi/go-avahi@v0.0.0-20240123155759-b4b6b2b50b4d/server.go:213
```
