### PR TITLE
Don't close DBUS connection when server session is closed

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,17 @@ func main() {
 	if err != nil {
 		log.Fatalf("Cannot get system bus: %v", err)
 	}
+	
+	// This is a globally shared connection. If there are other users of DBUS (whether in this library or others,
+	// this shouldn't be called until all users are done.
+	defer conn.Close()
 
 	server, err := avahi.ServerNew(conn)
 	if err != nil {
 		log.Fatalf("Avahi new failed: %v", err)
 	}
+	
+	defer server.Close()
 
 	host, err := server.GetHostName()
 	if err != nil {

--- a/server.go
+++ b/server.go
@@ -80,8 +80,6 @@ func (c *Server) Close() {
 		obj.free()
 		delete(c.signalEmitters, path)
 	}
-
-	c.conn.Close()
 }
 
 func (c *Server) interfaceForMember(method string) string {


### PR DESCRIPTION
When running multiple instances of this library (mainly in a server / client configuration in a single executable), calling `server.Close()` also closes the globally-shared DBUS connection. 

https://github.com/godbus/dbus/blob/master/conn.go#L13-L18

This is even noted in the usage notes for go-dbuses' `Close()` function:

https://github.com/godbus/dbus/blob/master/conn.go#L315-L318

This PR removes the automatic close while still allowing the individual Avahi session to be stopped thereby Free'ing listeners, etc.